### PR TITLE
Add missing quotes for rectangle

### DIFF
--- a/svg/shapes.py
+++ b/svg/shapes.py
@@ -42,7 +42,7 @@ class Rectangle(Shape):
         self.ry = ry
 
     def svg_content(self) -> str:
-        content = f'<rect width="{self.width}" height="{self.height}" x={self.x} y={self.y} style={self.style.svg()} rx={self.rx} ry={self.ry} />'
+        content = f'<rect width="{self.width}" height="{self.height}" x="{self.x}" y="{self.y}" style={self.style.svg()} rx={self.rx} ry={self.ry} />'
         return content
 
 


### PR DESCRIPTION
There is a problem with missing quotes for the x and y attribute
of the rectangular shape, preventing the Svg from rendering when these attributes are set.

In this pull request the missing quotes are added.